### PR TITLE
Reapply use "= default" to satisfy clang-tidy

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -446,7 +446,7 @@ class TestFactoryBase {
   virtual Test* CreateTest() = 0;
 
  protected:
-  TestFactoryBase() {}
+  TestFactoryBase() = default;
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(TestFactoryBase);
@@ -1355,7 +1355,7 @@ constexpr bool InstantiateTypedTestCase_P_IsDeprecated() { return true; }
   class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                    \
       : public parent_class {                                                 \
    public:                                                                    \
-    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() {}                   \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() = default;           \
                                                                               \
    private:                                                                   \
     virtual void TestBody();                                                  \


### PR DESCRIPTION
The changes from https://github.com/Esri/googletest/commit/58ce2723f5d7a86708db37d4b2621016abde8a26 were lost when the runtimecore branch was synced with
the latest GoogleTest version.