### PR TITLE
Craig/tag size

### DIFF
--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -411,7 +411,7 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
   return internal::CartesianProductHolder<Generator...>(g...);
 }
 
-#define TEST_P(test_suite_name, test_name)                                     \
+#define TEST_P_(test_suite_name, test_name, test_tag)                          \
   class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
       : public test_suite_name {                                               \
    public:                                                                     \
@@ -427,6 +427,7 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
               ::testing::internal::CodeLocation(__FILE__, __LINE__))           \
           ->AddTestPattern(                                                    \
               GTEST_STRINGIFY_(test_suite_name), GTEST_STRINGIFY_(test_name),  \
+              GTEST_STRINGIFY_(test_tag),                                      \
               new ::testing::internal::TestMetaFactory<GTEST_TEST_CLASS_NAME_( \
                   test_suite_name, test_name)>(),                              \
               ::testing::internal::CodeLocation(__FILE__, __LINE__));          \
@@ -440,6 +441,11 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
                              test_name)::gtest_registering_dummy_ =            \
       GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)::AddToRegistry();     \
   void GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)::TestBody()
+
+#if !GTEST_DONT_DEFINE_TEST
+#define TEST_P(test_suite_name, test_name) \
+  TEST_P_(test_suite_name, test_name, "ALL")
+#endif // !GTEST_DONT_DEFINE_TEST
 
 // The last argument to INSTANTIATE_TEST_SUITE_P allows the user to specify
 // generator and an optional function or functor that generates custom test name

--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -411,7 +411,7 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
   return internal::CartesianProductHolder<Generator...>(g...);
 }
 
-#define TEST_P_(test_suite_name, test_name, test_tag)                          \
+#define TEST_P_(test_suite_name, test_name, test_size, test_tag)               \
   class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
       : public test_suite_name {                                               \
    public:                                                                     \
@@ -427,7 +427,7 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
               ::testing::internal::CodeLocation(__FILE__, __LINE__))           \
           ->AddTestPattern(                                                    \
               GTEST_STRINGIFY_(test_suite_name), GTEST_STRINGIFY_(test_name),  \
-              GTEST_STRINGIFY_(test_tag),                                      \
+              (test_size), GTEST_STRINGIFY_(test_tag),                         \
               new ::testing::internal::TestMetaFactory<GTEST_TEST_CLASS_NAME_( \
                   test_suite_name, test_name)>(),                              \
               ::testing::internal::CodeLocation(__FILE__, __LINE__));          \
@@ -444,7 +444,7 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
 
 #if !GTEST_DONT_DEFINE_TEST
 #define TEST_P(test_suite_name, test_name) \
-  TEST_P_(test_suite_name, test_name, "ALL")
+  TEST_P_(test_suite_name, test_name, 'X', "ALL")
 #endif // !GTEST_DONT_DEFINE_TEST
 
 // The last argument to INSTANTIATE_TEST_SUITE_P allows the user to specify

--- a/googletest/include/gtest/gtest-typed-test.h
+++ b/googletest/include/gtest/gtest-typed-test.h
@@ -194,7 +194,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
   typedef ::testing::internal::NameGeneratorSelector<__VA_ARGS__>::type \
       GTEST_NAME_GENERATOR_(CaseName)
 
-#define TYPED_TEST(CaseName, TestName)                                        \
+#define TYPED_TEST_(CaseName, TestName, TestTag)                              \
   static_assert(sizeof(GTEST_STRINGIFY_(TestName)) > 1,                       \
                 "test-name must not be empty");                               \
   template <typename gtest_TypeParam_>                                        \
@@ -215,13 +215,19 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
                                    ::testing::internal::CodeLocation(         \
                                        __FILE__, __LINE__),                   \
                                    GTEST_STRINGIFY_(CaseName),                \
-                                   GTEST_STRINGIFY_(TestName), 0,             \
+                                   GTEST_STRINGIFY_(TestName),                \
+                                   GTEST_STRINGIFY_(TestTag), 0,              \
                                    ::testing::internal::GenerateNames<        \
                                        GTEST_NAME_GENERATOR_(CaseName),       \
                                        GTEST_TYPE_PARAMS_(CaseName)>());      \
   template <typename gtest_TypeParam_>                                        \
   void GTEST_TEST_CLASS_NAME_(CaseName,                                       \
                               TestName)<gtest_TypeParam_>::TestBody()
+
+#if !GTEST_DONT_DEFINE_TEST
+#define TYPED_TEST(CaseName, TestName) \
+  TYPED_TEST_(CaseName, TestName, "ALL")
+#endif // !GTEST_DONT_DEFINE_TEST
 
 // Legacy API is deprecated but still available
 #ifndef GTEST_REMOVE_LEGACY_TEST_CASEAPI_
@@ -271,7 +277,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
   TYPED_TEST_SUITE_P
 #endif  // GTEST_REMOVE_LEGACY_TEST_CASEAPI_
 
-#define TYPED_TEST_P(SuiteName, TestName)                             \
+#define TYPED_TEST_P_(SuiteName, TestName, TestTag)                   \
   namespace GTEST_SUITE_NAMESPACE_(SuiteName) {                       \
     template <typename gtest_TypeParam_>                              \
     class TestName : public SuiteName<gtest_TypeParam_> {             \
@@ -283,11 +289,17 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
     static bool gtest_##TestName##_defined_ GTEST_ATTRIBUTE_UNUSED_ = \
         GTEST_TYPED_TEST_SUITE_P_STATE_(SuiteName).AddTestName(       \
             __FILE__, __LINE__, GTEST_STRINGIFY_(SuiteName),          \
-            GTEST_STRINGIFY_(TestName));                              \
+            GTEST_STRINGIFY_(TestName),                               \
+            GTEST_STRINGIFY_(TestTag));                               \
   }                                                                   \
   template <typename gtest_TypeParam_>                                \
   void GTEST_SUITE_NAMESPACE_(                                        \
       SuiteName)::TestName<gtest_TypeParam_>::TestBody()
+
+#if !GTEST_DONT_DEFINE_TEST
+#define TYPED_TEST_P(SuiteName, TestName) \
+  TYPED_TEST_P_(SuiteName, TestName, "ALL")
+#endif // !GTEST_DONT_DEFINE_TEST
 
 // Note: this won't work correctly if the trailing arguments are macros.
 #define REGISTER_TYPED_TEST_SUITE_P(SuiteName, ...)                         \

--- a/googletest/include/gtest/gtest-typed-test.h
+++ b/googletest/include/gtest/gtest-typed-test.h
@@ -194,7 +194,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
   typedef ::testing::internal::NameGeneratorSelector<__VA_ARGS__>::type \
       GTEST_NAME_GENERATOR_(CaseName)
 
-#define TYPED_TEST_(CaseName, TestName, TestTag)                              \
+#define TYPED_TEST_(CaseName, TestName, TestSize, TestTag)                   \
   static_assert(sizeof(GTEST_STRINGIFY_(TestName)) > 1,                       \
                 "test-name must not be empty");                               \
   template <typename gtest_TypeParam_>                                        \
@@ -216,7 +216,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
                                        __FILE__, __LINE__),                   \
                                    GTEST_STRINGIFY_(CaseName),                \
                                    GTEST_STRINGIFY_(TestName),                \
-                                   GTEST_STRINGIFY_(TestTag), 0,              \
+                                   (TestSize), GTEST_STRINGIFY_(TestTag), 0,  \
                                    ::testing::internal::GenerateNames<        \
                                        GTEST_NAME_GENERATOR_(CaseName),       \
                                        GTEST_TYPE_PARAMS_(CaseName)>());      \
@@ -226,7 +226,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
 
 #if !GTEST_DONT_DEFINE_TEST
 #define TYPED_TEST(CaseName, TestName) \
-  TYPED_TEST_(CaseName, TestName, "ALL")
+  TYPED_TEST_(CaseName, TestName, 'X', "ALL")
 #endif // !GTEST_DONT_DEFINE_TEST
 
 // Legacy API is deprecated but still available
@@ -277,7 +277,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
   TYPED_TEST_SUITE_P
 #endif  // GTEST_REMOVE_LEGACY_TEST_CASEAPI_
 
-#define TYPED_TEST_P_(SuiteName, TestName, TestTag)                   \
+#define TYPED_TEST_P_(SuiteName, TestName, TestSize, TestTag)         \
   namespace GTEST_SUITE_NAMESPACE_(SuiteName) {                       \
     template <typename gtest_TypeParam_>                              \
     class TestName : public SuiteName<gtest_TypeParam_> {             \
@@ -290,7 +290,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
         GTEST_TYPED_TEST_SUITE_P_STATE_(SuiteName).AddTestName(       \
             __FILE__, __LINE__, GTEST_STRINGIFY_(SuiteName),          \
             GTEST_STRINGIFY_(TestName),                               \
-            GTEST_STRINGIFY_(TestTag));                               \
+            (TestSize), GTEST_STRINGIFY_(TestTag));                   \
   }                                                                   \
   template <typename gtest_TypeParam_>                                \
   void GTEST_SUITE_NAMESPACE_(                                        \
@@ -298,7 +298,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
 
 #if !GTEST_DONT_DEFINE_TEST
 #define TYPED_TEST_P(SuiteName, TestName) \
-  TYPED_TEST_P_(SuiteName, TestName, "ALL")
+  TYPED_TEST_P_(SuiteName, TestName, 'X', "ALL")
 #endif // !GTEST_DONT_DEFINE_TEST
 
 // Note: this won't work correctly if the trailing arguments are macros.

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -113,6 +113,10 @@ GTEST_DECLARE_string_(filter);
 // the tests to run. If the tag is not given all tests are executed.
 GTEST_DECLARE_string_(tag);
 
+// This flag sets up the size to select by name using a glob pattern
+// the tests to run. If the size is not given only small tests are executed.
+GTEST_DECLARE_string_(size);
+
 // This flag controls whether Google Test installs a signal handler that dumps
 // debugging information when fatal signals are raised.
 GTEST_DECLARE_bool_(install_failure_signal_handler);
@@ -725,6 +729,9 @@ class GTEST_API_ TestInfo {
   // Returns the test tag.
   const char* tag() const { return tag_.c_str(); }
 
+  // Returns the test size.
+  const char size() const { return size_; }
+
   // Returns the name of the parameter type, or NULL if this is not a typed
   // or a type-parameterized test.
   const char* type_param() const {
@@ -768,9 +775,10 @@ class GTEST_API_ TestInfo {
 
   // Returns true if and only if this test will appear in the XML report.
   bool is_reportable() const {
-    // The XML report includes tests matching the filter, tag, excluding
+    // The XML report includes tests matching the filter, size, tag, excluding
     // those run in other shards.
-    return matches_filter_ && matches_tag_ && !is_in_another_shard_;
+    return matches_filter_ && matches_size_ &&
+           matches_tag_ && !is_in_another_shard_;
   }
 
   // Returns the result of the test.
@@ -785,7 +793,7 @@ class GTEST_API_ TestInfo {
   friend class internal::UnitTestImpl;
   friend class internal::StreamingListenerTest;
   friend TestInfo* internal::MakeAndRegisterTestInfo(
-      const char* test_suite_name, const char* name, const char* tag,
+      const char* test_suite_name, const char* name, char size, const char* tag,
       const char* type_param, const char* value_param,
       internal::CodeLocation code_location, internal::TypeId fixture_class_id,
       internal::SetUpTestSuiteFunc set_up_tc,
@@ -795,7 +803,7 @@ class GTEST_API_ TestInfo {
   // Constructs a TestInfo object. The newly constructed instance assumes
   // ownership of the factory object.
   TestInfo(const std::string& test_suite_name, const std::string& name,
-           const std::string& tag,
+           char size, const std::string& tag,
            const char* a_type_param,   // NULL if not a type-parameterized test
            const char* a_value_param,  // NULL if not a value-parameterized test
            internal::CodeLocation a_code_location,
@@ -823,6 +831,7 @@ class GTEST_API_ TestInfo {
   const std::string test_suite_name_;  // test suite name
   const std::string name_;             // Test name
   const std::string tag_;              // Test tag
+  const char size_;                    // Test size
   // Name of the parameter type, or NULL if this is not a typed or a
   // type-parameterized test.
   const std::unique_ptr<const ::std::string> type_param_;
@@ -837,6 +846,8 @@ class GTEST_API_ TestInfo {
                               // user-specified filter.
   bool matches_tag_;          // True if this test matches the
                               // user-specified tag.
+  bool matches_size_;         // True if this test matches the
+                              // user-specified size.
   bool is_in_another_shard_;  // Will be run in another shard.
   internal::TestFactoryBase* const factory_;  // The factory that creates
                                               // the test object
@@ -2351,8 +2362,8 @@ constexpr bool StaticAssertTypeEq() noexcept {
 // code.  GetTestTypeId() is guaranteed to always return the same
 // value, as it always calls GetTypeId<>() from the Google Test
 // framework.
-#define GTEST_TEST(test_suite_name, test_name)                    \
-  GTEST_TEST_(test_suite_name, test_name, "ALL", ::testing::Test, \
+#define GTEST_TEST(test_suite_name, test_name)                        \
+  GTEST_TEST_(test_suite_name, test_name, 'X', "ALL", ::testing::Test, \
               ::testing::internal::GetTestTypeId())
 
 // Define this macro to 1 to omit the definition of TEST(), which
@@ -2390,7 +2401,7 @@ constexpr bool StaticAssertTypeEq() noexcept {
 // GOOGLETEST_CM0011 DO NOT DELETE
 #if !GTEST_DONT_DEFINE_TEST
 #define TEST_F(test_fixture, test_name)\
-  GTEST_TEST_(test_fixture, test_name, "ALL", test_fixture, \
+  GTEST_TEST_(test_fixture, test_name, 'X', "ALL", test_fixture, \
               ::testing::internal::GetTypeId<test_fixture>())
 #endif  // !GTEST_DONT_DEFINE_TEST
 
@@ -2461,7 +2472,8 @@ GTEST_API_ std::string TempDir();
 //
 template <int&... ExplicitParameterBarrier, typename Factory>
 TestInfo* RegisterTest(const char* test_suite_name, const char* test_name,
-                       const char* test_tag, const char* type_param,
+                       char test_size, const char* test_tag,
+                       const char* type_param,
                        const char* value_param, const char* file, int line,
                        Factory factory) {
   using TestT = typename std::remove_pointer<decltype(factory())>::type;
@@ -2476,7 +2488,7 @@ TestInfo* RegisterTest(const char* test_suite_name, const char* test_name,
   };
 
   return internal::MakeAndRegisterTestInfo(
-      test_suite_name, test_name, test_tag, type_param, value_param,
+      test_suite_name, test_name, test_size, test_tag, type_param, value_param,
       internal::CodeLocation(file, line), internal::GetTypeId<TestT>(),
       internal::SuiteApiResolver<TestT>::GetSetUpCaseOrSuite(file, line),
       internal::SuiteApiResolver<TestT>::GetTearDownCaseOrSuite(file, line),

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -109,6 +109,10 @@ GTEST_DECLARE_bool_(fail_fast);
 // the tests to run. If the filter is not given all tests are executed.
 GTEST_DECLARE_string_(filter);
 
+// This flag sets up the tag to select by name using a glob pattern
+// the tests to run. If the tag is not given all tests are executed.
+GTEST_DECLARE_string_(tag);
+
 // This flag controls whether Google Test installs a signal handler that dumps
 // debugging information when fatal signals are raised.
 GTEST_DECLARE_bool_(install_failure_signal_handler);
@@ -718,6 +722,9 @@ class GTEST_API_ TestInfo {
   // Returns the test name.
   const char* name() const { return name_.c_str(); }
 
+  // Returns the test tag.
+  const char* tag() const { return tag_.c_str(); }
+
   // Returns the name of the parameter type, or NULL if this is not a typed
   // or a type-parameterized test.
   const char* type_param() const {
@@ -761,9 +768,9 @@ class GTEST_API_ TestInfo {
 
   // Returns true if and only if this test will appear in the XML report.
   bool is_reportable() const {
-    // The XML report includes tests matching the filter, excluding those
-    // run in other shards.
-    return matches_filter_ && !is_in_another_shard_;
+    // The XML report includes tests matching the filter, tag, excluding
+    // those run in other shards.
+    return matches_filter_ && matches_tag_ && !is_in_another_shard_;
   }
 
   // Returns the result of the test.
@@ -778,15 +785,17 @@ class GTEST_API_ TestInfo {
   friend class internal::UnitTestImpl;
   friend class internal::StreamingListenerTest;
   friend TestInfo* internal::MakeAndRegisterTestInfo(
-      const char* test_suite_name, const char* name, const char* type_param,
-      const char* value_param, internal::CodeLocation code_location,
-      internal::TypeId fixture_class_id, internal::SetUpTestSuiteFunc set_up_tc,
+      const char* test_suite_name, const char* name, const char* tag,
+      const char* type_param, const char* value_param,
+      internal::CodeLocation code_location, internal::TypeId fixture_class_id,
+      internal::SetUpTestSuiteFunc set_up_tc,
       internal::TearDownTestSuiteFunc tear_down_tc,
       internal::TestFactoryBase* factory);
 
   // Constructs a TestInfo object. The newly constructed instance assumes
   // ownership of the factory object.
   TestInfo(const std::string& test_suite_name, const std::string& name,
+           const std::string& tag,
            const char* a_type_param,   // NULL if not a type-parameterized test
            const char* a_value_param,  // NULL if not a value-parameterized test
            internal::CodeLocation a_code_location,
@@ -811,8 +820,9 @@ class GTEST_API_ TestInfo {
   }
 
   // These fields are immutable properties of the test.
-  const std::string test_suite_name_;    // test suite name
-  const std::string name_;               // Test name
+  const std::string test_suite_name_;  // test suite name
+  const std::string name_;             // Test name
+  const std::string tag_;              // Test tag
   // Name of the parameter type, or NULL if this is not a typed or a
   // type-parameterized test.
   const std::unique_ptr<const ::std::string> type_param_;
@@ -825,6 +835,8 @@ class GTEST_API_ TestInfo {
   bool is_disabled_;          // True if and only if this test is disabled
   bool matches_filter_;       // True if this test matches the
                               // user-specified filter.
+  bool matches_tag_;          // True if this test matches the
+                              // user-specified tag.
   bool is_in_another_shard_;  // Will be run in another shard.
   internal::TestFactoryBase* const factory_;  // The factory that creates
                                               // the test object
@@ -2339,15 +2351,15 @@ constexpr bool StaticAssertTypeEq() noexcept {
 // code.  GetTestTypeId() is guaranteed to always return the same
 // value, as it always calls GetTypeId<>() from the Google Test
 // framework.
-#define GTEST_TEST(test_suite_name, test_name)             \
-  GTEST_TEST_(test_suite_name, test_name, ::testing::Test, \
+#define GTEST_TEST(test_suite_name, test_name)                    \
+  GTEST_TEST_(test_suite_name, test_name, "ALL", ::testing::Test, \
               ::testing::internal::GetTestTypeId())
 
 // Define this macro to 1 to omit the definition of TEST(), which
 // is a generic name and clashes with some other libraries.
 #if !GTEST_DONT_DEFINE_TEST
 #define TEST(test_suite_name, test_name) GTEST_TEST(test_suite_name, test_name)
-#endif
+#endif // !GTEST_DONT_DEFINE_TEST
 
 // Defines a test that uses a test fixture.
 //
@@ -2378,7 +2390,7 @@ constexpr bool StaticAssertTypeEq() noexcept {
 // GOOGLETEST_CM0011 DO NOT DELETE
 #if !GTEST_DONT_DEFINE_TEST
 #define TEST_F(test_fixture, test_name)\
-  GTEST_TEST_(test_fixture, test_name, test_fixture, \
+  GTEST_TEST_(test_fixture, test_name, "ALL", test_fixture, \
               ::testing::internal::GetTypeId<test_fixture>())
 #endif  // !GTEST_DONT_DEFINE_TEST
 
@@ -2449,8 +2461,9 @@ GTEST_API_ std::string TempDir();
 //
 template <int&... ExplicitParameterBarrier, typename Factory>
 TestInfo* RegisterTest(const char* test_suite_name, const char* test_name,
-                       const char* type_param, const char* value_param,
-                       const char* file, int line, Factory factory) {
+                       const char* test_tag, const char* type_param,
+                       const char* value_param, const char* file, int line,
+                       Factory factory) {
   using TestT = typename std::remove_pointer<decltype(factory())>::type;
 
   class FactoryImpl : public internal::TestFactoryBase {
@@ -2463,7 +2476,7 @@ TestInfo* RegisterTest(const char* test_suite_name, const char* test_name,
   };
 
   return internal::MakeAndRegisterTestInfo(
-      test_suite_name, test_name, type_param, value_param,
+      test_suite_name, test_name, test_tag, type_param, value_param,
       internal::CodeLocation(file, line), internal::GetTypeId<TestT>(),
       internal::SuiteApiResolver<TestT>::GetSetUpCaseOrSuite(file, line),
       internal::SuiteApiResolver<TestT>::GetTearDownCaseOrSuite(file, line),

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -568,6 +568,7 @@ struct SuiteApiResolver : T {
 //
 //   test_suite_name:   name of the test suite
 //   name:             name of the test
+//   tag:              tag of the test
 //   type_param        the name of the test's type parameter, or NULL if
 //                     this is not a typed or a type-parameterized test.
 //   value_param       text representation of the test's value parameter,
@@ -580,8 +581,8 @@ struct SuiteApiResolver : T {
 //                     The newly created TestInfo instance will assume
 //                     ownership of the factory object.
 GTEST_API_ TestInfo* MakeAndRegisterTestInfo(
-    const char* test_suite_name, const char* name, const char* type_param,
-    const char* value_param, CodeLocation code_location,
+    const char* test_suite_name, const char* name, const char* tag,
+    const char* type_param, const char* value_param, CodeLocation code_location,
     TypeId fixture_class_id, SetUpTestSuiteFunc set_up_tc,
     TearDownTestSuiteFunc tear_down_tc, TestFactoryBase* factory);
 
@@ -597,6 +598,12 @@ GTEST_DISABLE_MSC_WARNINGS_PUSH_(4251 \
 
 // State of the definition of a type-parameterized test suite.
 class GTEST_API_ TypedTestSuitePState {
+   struct TypedTestState
+   {
+     CodeLocation codeLocation;
+     const std::string tag;
+   };
+
  public:
   TypedTestSuitePState() : registered_(false) {}
 
@@ -604,7 +611,7 @@ class GTEST_API_ TypedTestSuitePState {
   // if the test suite hasn't been registered; otherwise aborts the
   // program.
   bool AddTestName(const char* file, int line, const char* case_name,
-                   const char* test_name) {
+                   const char* test_name, const char* test_tag) {
     if (registered_) {
       fprintf(stderr,
               "%s Test %s must be defined before "
@@ -614,7 +621,9 @@ class GTEST_API_ TypedTestSuitePState {
       posix::Abort();
     }
     registered_tests_.insert(
-        ::std::make_pair(test_name, CodeLocation(file, line)));
+    ::std::make_pair<std::string, TypedTestState>(test_name,
+                                                  {CodeLocation(file, line),
+                                                   test_tag}));
     return true;
   }
 
@@ -625,7 +634,13 @@ class GTEST_API_ TypedTestSuitePState {
   const CodeLocation& GetCodeLocation(const std::string& test_name) const {
     RegisteredTestsMap::const_iterator it = registered_tests_.find(test_name);
     GTEST_CHECK_(it != registered_tests_.end());
-    return it->second;
+    return it->second.codeLocation;
+  }
+
+  const std::string& GetTag(const std::string& test_name) const {
+    RegisteredTestsMap::const_iterator it = registered_tests_.find(test_name);
+    GTEST_CHECK_(it != registered_tests_.end());
+    return it->second.tag;
   }
 
   // Verifies that registered_tests match the test names in
@@ -636,7 +651,7 @@ class GTEST_API_ TypedTestSuitePState {
                                         const char* registered_tests);
 
  private:
-  typedef ::std::map<std::string, CodeLocation> RegisteredTestsMap;
+  typedef ::std::map<std::string, TypedTestState> RegisteredTestsMap;
 
   bool registered_;
   RegisteredTestsMap registered_tests_;
@@ -718,7 +733,8 @@ class TypeParameterizedTest {
   // Types).  Valid values for 'index' are [0, N - 1] where N is the
   // length of Types.
   static bool Register(const char* prefix, const CodeLocation& code_location,
-                       const char* case_name, const char* test_names, int index,
+                       const char* case_name, const char* test_names,
+                       const char* test_tag, int index,
                        const std::vector<std::string>& type_names =
                            GenerateNames<DefaultNameGenerator, Types>()) {
     typedef typename Types::Head Type;
@@ -732,7 +748,7 @@ class TypeParameterizedTest {
          "/" + type_names[static_cast<size_t>(index)])
             .c_str(),
         StripTrailingSpaces(GetPrefixUntilComma(test_names)).c_str(),
-        GetTypeName<Type>().c_str(),
+        test_tag, GetTypeName<Type>().c_str(),
         nullptr,  // No value parameter.
         code_location, GetTypeId<FixtureClass>(),
         SuiteApiResolver<TestClass>::GetSetUpCaseOrSuite(
@@ -747,6 +763,7 @@ class TypeParameterizedTest {
                                                                  code_location,
                                                                  case_name,
                                                                  test_names,
+                                                                 test_tag,
                                                                  index + 1,
                                                                  type_names);
   }
@@ -758,7 +775,7 @@ class TypeParameterizedTest<Fixture, TestSel, internal::None> {
  public:
   static bool Register(const char* /*prefix*/, const CodeLocation&,
                        const char* /*case_name*/, const char* /*test_names*/,
-                       int /*index*/,
+                       const char* /*test_tag*/, int /*index*/,
                        const std::vector<std::string>& =
                            std::vector<std::string>() /*type_names*/) {
     return true;
@@ -794,12 +811,14 @@ class TypeParameterizedTestSuite {
       posix::Abort();
     }
     const CodeLocation& test_location = state->GetCodeLocation(test_name);
+    const std::string& test_tag = state->GetTag(test_name);
 
     typedef typename Tests::Head Head;
 
     // First, register the first test in 'Test' for each type in 'Types'.
     TypeParameterizedTest<Fixture, Head, Types>::Register(
-        prefix, test_location, case_name, test_names, 0, type_names);
+        prefix, test_location, case_name, test_names, test_tag.c_str(), 0,
+        type_names);
 
     // Next, recurses (at compile time) with the tail of the test list.
     return TypeParameterizedTestSuite<Fixture, typename Tests::Tail,
@@ -1462,7 +1481,8 @@ class NeverThrown {
   test_suite_name##_##test_name##_Test
 
 // Helper macro for defining tests.
-#define GTEST_TEST_(test_suite_name, test_name, parent_class, parent_id)      \
+#define GTEST_TEST_(test_suite_name, test_name, test_tag,                     \
+                    parent_class, parent_id)                                  \
   static_assert(sizeof(GTEST_STRINGIFY_(test_suite_name)) > 1,                \
                 "test_suite_name must not be empty");                         \
   static_assert(sizeof(GTEST_STRINGIFY_(test_name)) > 1,                      \
@@ -1485,7 +1505,7 @@ class NeverThrown {
   ::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(test_suite_name,          \
                                                     test_name)::test_info_ =  \
       ::testing::internal::MakeAndRegisterTestInfo(                           \
-          #test_suite_name, #test_name, nullptr, nullptr,                     \
+          #test_suite_name, #test_name, #test_tag, nullptr, nullptr,          \
           ::testing::internal::CodeLocation(__FILE__, __LINE__), (parent_id), \
           ::testing::internal::SuiteApiResolver<                              \
               parent_class>::GetSetUpCaseOrSuite(__FILE__, __LINE__),         \

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -520,11 +520,12 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
   // parameter index. For the test SequenceA/FooTest.DoBar/1 FooTest is
   // test suite base name and DoBar is test base name.
   void AddTestPattern(const char* test_suite_name, const char* test_base_name,
-                      const char* test_tag,
+                      char test_size, const char* test_tag,
                       TestMetaFactoryBase<ParamType>* meta_factory,
                       CodeLocation code_location) {
     tests_.push_back(std::shared_ptr<TestInfo>(new TestInfo(
-        test_suite_name, test_base_name, test_tag, meta_factory, code_location)));
+        test_suite_name, test_base_name, test_size, test_tag, meta_factory,
+        code_location)));
   }
   // INSTANTIATE_TEST_SUITE_P macro uses AddGenerator() to record information
   // about a generator.
@@ -590,7 +591,7 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
           test_name_stream << param_name;
           MakeAndRegisterTestInfo(
               test_suite_name.c_str(), test_name_stream.GetString().c_str(),
-              test_info->test_tag.c_str(),
+              test_info->test_size, test_info->test_tag.c_str(),
               nullptr,  // No type parameter.
               PrintToString(*param_it).c_str(), test_info->code_location,
               GetTestSuiteTypeId(),
@@ -613,20 +614,22 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
   // with TEST_P macro.
   struct TestInfo {
     TestInfo(const char* a_test_suite_base_name, const char* a_test_base_name,
-             const char* a_test_tag,
+             char a_test_size, const char* a_test_tag,
              TestMetaFactoryBase<ParamType>* a_test_meta_factory,
              CodeLocation a_code_location)
         : test_suite_base_name(a_test_suite_base_name),
           test_base_name(a_test_base_name),
           test_tag(a_test_tag),
           test_meta_factory(a_test_meta_factory),
-          code_location(a_code_location) {}
+          code_location(a_code_location),
+          test_size(a_test_size) {}
 
     const std::string test_suite_base_name;
     const std::string test_base_name;
     const std::string test_tag;
     const std::unique_ptr<TestMetaFactoryBase<ParamType> > test_meta_factory;
     const CodeLocation code_location;
+    const char test_size;
   };
   using TestInfoContainer = ::std::vector<std::shared_ptr<TestInfo> >;
   // Records data received from INSTANTIATE_TEST_SUITE_P macros:

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -520,10 +520,11 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
   // parameter index. For the test SequenceA/FooTest.DoBar/1 FooTest is
   // test suite base name and DoBar is test base name.
   void AddTestPattern(const char* test_suite_name, const char* test_base_name,
+                      const char* test_tag,
                       TestMetaFactoryBase<ParamType>* meta_factory,
                       CodeLocation code_location) {
     tests_.push_back(std::shared_ptr<TestInfo>(new TestInfo(
-        test_suite_name, test_base_name, meta_factory, code_location)));
+        test_suite_name, test_base_name, test_tag, meta_factory, code_location)));
   }
   // INSTANTIATE_TEST_SUITE_P macro uses AddGenerator() to record information
   // about a generator.
@@ -589,6 +590,7 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
           test_name_stream << param_name;
           MakeAndRegisterTestInfo(
               test_suite_name.c_str(), test_name_stream.GetString().c_str(),
+              test_info->test_tag.c_str(),
               nullptr,  // No type parameter.
               PrintToString(*param_it).c_str(), test_info->code_location,
               GetTestSuiteTypeId(),
@@ -611,15 +613,18 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
   // with TEST_P macro.
   struct TestInfo {
     TestInfo(const char* a_test_suite_base_name, const char* a_test_base_name,
+             const char* a_test_tag,
              TestMetaFactoryBase<ParamType>* a_test_meta_factory,
              CodeLocation a_code_location)
         : test_suite_base_name(a_test_suite_base_name),
           test_base_name(a_test_base_name),
+          test_tag(a_test_tag),
           test_meta_factory(a_test_meta_factory),
           code_location(a_code_location) {}
 
     const std::string test_suite_base_name;
     const std::string test_base_name;
+    const std::string test_tag;
     const std::unique_ptr<TestMetaFactoryBase<ParamType> > test_meta_factory;
     const CodeLocation code_location;
   };

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -87,6 +87,7 @@ const char kColorFlag[] = "color";
 const char kFailFast[] = "fail_fast";
 const char kFilterFlag[] = "filter";
 const char kTagFlag[] = "tag";
+const char kSizeFlag[] = "size";
 const char kListTestsFlag[] = "list_tests";
 const char kOutputFlag[] = "output";
 const char kBriefFlag[] = "brief";
@@ -170,6 +171,7 @@ class GTestFlagSaver {
     fail_fast_ = GTEST_FLAG(fail_fast);
     filter_ = GTEST_FLAG(filter);
     tag_ = GTEST_FLAG(tag);
+    size_ = GTEST_FLAG(size);
     internal_run_death_test_ = GTEST_FLAG(internal_run_death_test);
     list_tests_ = GTEST_FLAG(list_tests);
     output_ = GTEST_FLAG(output);
@@ -194,6 +196,7 @@ class GTestFlagSaver {
     GTEST_FLAG(death_test_use_fork) = death_test_use_fork_;
     GTEST_FLAG(filter) = filter_;
     GTEST_FLAG(tag) = tag_;
+    GTEST_FLAG(size) = size_;
     GTEST_FLAG(fail_fast) = fail_fast_;
     GTEST_FLAG(internal_run_death_test) = internal_run_death_test_;
     GTEST_FLAG(list_tests) = list_tests_;
@@ -220,6 +223,7 @@ class GTestFlagSaver {
   bool fail_fast_;
   std::string filter_;
   std::string tag_;
+  std::string size_;
   std::string internal_run_death_test_;
   bool list_tests_;
   std::string output_;
@@ -413,6 +417,10 @@ class GTEST_API_ UnitTestOptions {
   // Returns true if and only if the user-specified tag matches the test
   // tag.
   static bool TagMatchesTest(const std::string& test_tag);
+
+  // Returns true if and only if the user-specified size matches the test
+  // size.
+  static bool SizeMatchesTest(const std::string&  test_size);
 
 #if GTEST_OS_WINDOWS
   // Function for supporting the gtest_catch_exception flag.

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -86,6 +86,7 @@ const char kCatchExceptionsFlag[] = "catch_exceptions";
 const char kColorFlag[] = "color";
 const char kFailFast[] = "fail_fast";
 const char kFilterFlag[] = "filter";
+const char kTagFlag[] = "tag";
 const char kListTestsFlag[] = "list_tests";
 const char kOutputFlag[] = "output";
 const char kBriefFlag[] = "brief";
@@ -168,6 +169,7 @@ class GTestFlagSaver {
     death_test_use_fork_ = GTEST_FLAG(death_test_use_fork);
     fail_fast_ = GTEST_FLAG(fail_fast);
     filter_ = GTEST_FLAG(filter);
+    tag_ = GTEST_FLAG(tag);
     internal_run_death_test_ = GTEST_FLAG(internal_run_death_test);
     list_tests_ = GTEST_FLAG(list_tests);
     output_ = GTEST_FLAG(output);
@@ -191,6 +193,7 @@ class GTestFlagSaver {
     GTEST_FLAG(death_test_style) = death_test_style_;
     GTEST_FLAG(death_test_use_fork) = death_test_use_fork_;
     GTEST_FLAG(filter) = filter_;
+    GTEST_FLAG(tag) = tag_;
     GTEST_FLAG(fail_fast) = fail_fast_;
     GTEST_FLAG(internal_run_death_test) = internal_run_death_test_;
     GTEST_FLAG(list_tests) = list_tests_;
@@ -216,6 +219,7 @@ class GTestFlagSaver {
   bool death_test_use_fork_;
   bool fail_fast_;
   std::string filter_;
+  std::string tag_;
   std::string internal_run_death_test_;
   bool list_tests_;
   std::string output_;
@@ -405,6 +409,10 @@ class GTEST_API_ UnitTestOptions {
   // suite name and the test name.
   static bool FilterMatchesTest(const std::string& test_suite_name,
                                 const std::string& test_name);
+
+  // Returns true if and only if the user-specified tag matches the test
+  // tag.
+  static bool TagMatchesTest(const std::string& test_tag);
 
 #if GTEST_OS_WINDOWS
   // Function for supporting the gtest_catch_exception flag.

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -204,6 +204,14 @@ static const char* GetDefaultFilter() {
   }
   return kUniversalFilter;
 }
+static const char* GetDefaultTag() {
+  const char* const testbridge_tag_only =
+      internal::posix::GetEnv("TESTBRIDGE_TAG_ONLY");
+  if (testbridge_tag_only != nullptr) {
+    return testbridge_tag_only;
+  }
+  return kUniversalFilter;
+}
 
 // Bazel passes in the argument to '--test_runner_fail_fast' via the
 // TESTBRIDGE_TEST_RUNNER_FAIL_FAST environment variable.
@@ -249,6 +257,15 @@ GTEST_DEFINE_string_(
     "A colon-separated list of glob (not regex) patterns "
     "for filtering the tests to run, optionally followed by a "
     "'-' and a : separated list of negative patterns (tests to "
+    "exclude).  A test is run if it matches one of the positive "
+    "patterns and does not match any of the negative patterns.");
+
+GTEST_DEFINE_string_(
+    tag,
+    internal::StringFromGTestEnv("tag", GetDefaultTag()),
+    "A colon-separated list of glob (not regex) patterns "
+    "for filtering the tests to run based on tag, optionally followed by "
+    "a '-' and a : separated list of negative patterns (tests to "
     "exclude).  A test is run if it matches one of the positive "
     "patterns and does not match any of the negative patterns.");
 
@@ -501,6 +518,7 @@ void InsertSyntheticTestCase(const std::string& name, CodeLocation location,
   std::string full_name = "UninstantiatedParameterizedTestSuite<" + name + ">";
   RegisterTest(  //
       "GoogleTestVerification", full_name.c_str(),
+      "",       // No tag parameter.
       nullptr,  // No type parameter.
       nullptr,  // No value parameter.
       location.file.c_str(), location.line, [message, location] {
@@ -564,6 +582,7 @@ void TypeParameterizedTestSuiteRegistry::CheckForInstantiations() {
         "UninstantiatedTypeParameterizedTestSuite<" + testcase.first + ">";
     RegisterTest(  //
         "GoogleTestVerification", full_name.c_str(),
+        "",       // No tag parameter.
         nullptr,  // No type parameter.
         nullptr,  // No value parameter.
         testcase.second.code_location.file.c_str(),
@@ -717,6 +736,33 @@ bool UnitTestOptions::FilterMatchesTest(const std::string& test_suite_name,
   // test if any pattern in it matches the test.
   return (MatchesFilter(full_name, positive.c_str()) &&
           !MatchesFilter(full_name, negative.c_str()));
+}
+
+// Returns true if and only if the user-specified tag matches the test
+// tag.
+bool UnitTestOptions::TagMatchesTest(const std::string& test_tag) {
+  // Split --gtest_tag at '-', if there is one, to separate into
+  // positive tag and negative tag portions
+  const char* const p = GTEST_FLAG(tag).c_str();
+  const char* const dash = strchr(p, '-');
+  std::string positive;
+  std::string negative;
+  if (dash == nullptr) {
+    positive = GTEST_FLAG(tag).c_str();  // Whole string is a positive tag
+    negative = "";
+  } else {
+    positive = std::string(p, dash);   // Everything up to the dash
+    negative = std::string(dash + 1);  // Everything after the dash
+    if (positive.empty()) {
+      // Treat '-test1' as the same as '*-test1'
+      positive = kUniversalFilter;
+    }
+  }
+
+  // A tag is a colon-separated list of patterns.  It matches a
+  // test if any pattern in it matches the test.
+  return (MatchesFilter(test_tag, positive.c_str()) &&
+          !MatchesFilter(test_tag, negative.c_str()));
 }
 
 #if GTEST_HAS_SEH
@@ -2710,13 +2756,14 @@ bool Test::IsSkipped() {
 // Constructs a TestInfo object. It assumes ownership of the test factory
 // object.
 TestInfo::TestInfo(const std::string& a_test_suite_name,
-                   const std::string& a_name, const char* a_type_param,
-                   const char* a_value_param,
+                   const std::string& a_name, const std::string& a_tag,
+                   const char* a_type_param, const char* a_value_param,
                    internal::CodeLocation a_code_location,
                    internal::TypeId fixture_class_id,
                    internal::TestFactoryBase* factory)
     : test_suite_name_(a_test_suite_name),
       name_(a_name),
+      tag_(a_tag),
       type_param_(a_type_param ? new std::string(a_type_param) : nullptr),
       value_param_(a_value_param ? new std::string(a_value_param) : nullptr),
       location_(a_code_location),
@@ -2724,6 +2771,7 @@ TestInfo::TestInfo(const std::string& a_test_suite_name,
       should_run_(false),
       is_disabled_(false),
       matches_filter_(false),
+      matches_tag_(false),
       factory_(factory),
       result_() {}
 
@@ -2739,6 +2787,7 @@ namespace internal {
 //
 //   test_suite_name:   name of the test suite
 //   name:             name of the test
+//   tag:              tag of the test
 //   type_param:       the name of the test's type parameter, or NULL if
 //                     this is not a typed or a type-parameterized test.
 //   value_param:      text representation of the test's value parameter,
@@ -2751,12 +2800,12 @@ namespace internal {
 //                     The newly created TestInfo instance will assume
 //                     ownership of the factory object.
 TestInfo* MakeAndRegisterTestInfo(
-    const char* test_suite_name, const char* name, const char* type_param,
-    const char* value_param, CodeLocation code_location,
+    const char* test_suite_name, const char* name, const char* tag,
+    const char* type_param, const char* value_param, CodeLocation code_location,
     TypeId fixture_class_id, SetUpTestSuiteFunc set_up_tc,
     TearDownTestSuiteFunc tear_down_tc, TestFactoryBase* factory) {
   TestInfo* const test_info =
-      new TestInfo(test_suite_name, name, type_param, value_param,
+      new TestInfo(test_suite_name, name, tag, type_param, value_param,
                    code_location, fixture_class_id, factory);
   GetUnitTestImpl()->AddTestInfo(set_up_tc, tear_down_tc, test_info);
   return test_info;
@@ -3392,6 +3441,15 @@ void PrettyUnitTestResultPrinter::OnTestIterationStart(
   if (!String::CStringEquals(filter, kUniversalFilter)) {
     ColoredPrintf(GTestColor::kYellow, "Note: %s filter = %s\n", GTEST_NAME_,
                   filter);
+  }
+
+  const char* const tag = GTEST_FLAG(tag).c_str();
+
+  // Prints the tag if it's not *.  This reminds the user that some
+  // tests may be skipped.
+  if (!String::CStringEquals(tag, kUniversalFilter)) {
+    ColoredPrintf(GTestColor::kYellow, "Note: %s tag = %s\n",
+                  GTEST_NAME_, tag);
   }
 
   if (internal::ShouldShard(kTestTotalShards, kTestShardIndex, false)) {
@@ -5899,6 +5957,7 @@ int UnitTestImpl::FilterTests(ReactionToSharding shard_tests) {
     for (size_t j = 0; j < test_suite->test_info_list().size(); j++) {
       TestInfo* const test_info = test_suite->test_info_list()[j];
       const std::string test_name(test_info->name());
+      const std::string test_tag(test_info->tag());
       // A test is disabled if test suite name or test name matches
       // kDisableTestFilter.
       const bool is_disabled = internal::UnitTestOptions::MatchesFilter(
@@ -5911,9 +5970,13 @@ int UnitTestImpl::FilterTests(ReactionToSharding shard_tests) {
           test_suite_name, test_name);
       test_info->matches_filter_ = matches_filter;
 
+      const bool matches_tag = internal::UnitTestOptions::TagMatchesTest(test_tag);
+
+      test_info->matches_tag_ = matches_tag;
+
       const bool is_runnable =
           (GTEST_FLAG(also_run_disabled_tests) || !is_disabled) &&
-          matches_filter;
+          matches_filter && matches_tag;
 
       const bool is_in_another_shard =
           shard_tests != IGNORE_SHARDING_PROTOCOL &&
@@ -5963,7 +6026,7 @@ void UnitTestImpl::ListTestsMatchingFilter() {
 
     for (size_t j = 0; j < test_suite->test_info_list().size(); j++) {
       const TestInfo* const test_info = test_suite->test_info_list()[j];
-      if (test_info->matches_filter_) {
+      if (test_info->matches_filter_ && test_info->matches_tag_) {
         if (!printed_test_suite_name) {
           printed_test_suite_name = true;
           printf("%s.", test_suite->name());
@@ -6282,6 +6345,14 @@ static const char kColorEncodedHelpMessage[] =
     "'*'\n"
     "      matches any substring; ':' separates two patterns.\n"
     "  @G--" GTEST_FLAG_PREFIX_
+    "tag=@YPOSTIVE_PATTERNS"
+    "[@G-@YNEGATIVE_PATTERNS]@D\n"
+    "      Run only the tests whose tag matches one of the positive "
+    "patterns but\n"
+    "      none of the negative patterns. '?' matches any single character; "
+    "'*'\n"
+    "      matches any substring; ':' separates two patterns.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
     "also_run_disabled_tests@D\n"
     "      Run all disabled tests too.\n"
     "\n"
@@ -6369,6 +6440,7 @@ static bool ParseGoogleTestFlag(const char* const arg) {
                        &GTEST_FLAG(death_test_use_fork)) ||
          ParseBoolFlag(arg, kFailFast, &GTEST_FLAG(fail_fast)) ||
          ParseStringFlag(arg, kFilterFlag, &GTEST_FLAG(filter)) ||
+         ParseStringFlag(arg, kTagFlag, &GTEST_FLAG(tag)) ||
          ParseStringFlag(arg, kInternalRunDeathTestFlag,
                          &GTEST_FLAG(internal_run_death_test)) ||
          ParseBoolFlag(arg, kListTestsFlag, &GTEST_FLAG(list_tests)) ||

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -204,11 +204,25 @@ static const char* GetDefaultFilter() {
   }
   return kUniversalFilter;
 }
+
+// Bazel passes in the argument to '--test_tag' via the TESTBRIDGE_TAG_ONLY
+// environment variable.
 static const char* GetDefaultTag() {
   const char* const testbridge_tag_only =
       internal::posix::GetEnv("TESTBRIDGE_TAG_ONLY");
   if (testbridge_tag_only != nullptr) {
     return testbridge_tag_only;
+  }
+  return kUniversalFilter;
+}
+
+// Bazel passes in the argument to '--test_size' via the TESTBRIDGE_SIZE_ONLY
+// environment variable.
+static const char* GetDefaultSize() {
+  char const* testbridge_size_only =
+      internal::posix::GetEnv("TESTBRIDGE_SIZE_ONLY");
+  if (testbridge_size_only != nullptr) {
+    return testbridge_size_only;
   }
   return kUniversalFilter;
 }
@@ -265,6 +279,15 @@ GTEST_DEFINE_string_(
     internal::StringFromGTestEnv("tag", GetDefaultTag()),
     "A colon-separated list of glob (not regex) patterns "
     "for filtering the tests to run based on tag, optionally followed by "
+    "a '-' and a : separated list of negative patterns (tests to "
+    "exclude).  A test is run if it matches one of the positive "
+    "patterns and does not match any of the negative patterns.");
+
+GTEST_DEFINE_string_(
+    size,
+    internal::StringFromGTestEnv("size", GetDefaultSize()),
+    "A colon-separated list of glob (not regex) patterns "
+    "for filtering the tests to run based on size, optionally followed by "
     "a '-' and a : separated list of negative patterns (tests to "
     "exclude).  A test is run if it matches one of the positive "
     "patterns and does not match any of the negative patterns.");
@@ -518,6 +541,7 @@ void InsertSyntheticTestCase(const std::string& name, CodeLocation location,
   std::string full_name = "UninstantiatedParameterizedTestSuite<" + name + ">";
   RegisterTest(  //
       "GoogleTestVerification", full_name.c_str(),
+      'S',      // Default size parameter
       "",       // No tag parameter.
       nullptr,  // No type parameter.
       nullptr,  // No value parameter.
@@ -582,6 +606,7 @@ void TypeParameterizedTestSuiteRegistry::CheckForInstantiations() {
         "UninstantiatedTypeParameterizedTestSuite<" + testcase.first + ">";
     RegisterTest(  //
         "GoogleTestVerification", full_name.c_str(),
+        'S',      // Default size parameter
         "",       // No tag parameter.
         nullptr,  // No type parameter.
         nullptr,  // No value parameter.
@@ -763,6 +788,33 @@ bool UnitTestOptions::TagMatchesTest(const std::string& test_tag) {
   // test if any pattern in it matches the test.
   return (MatchesFilter(test_tag, positive.c_str()) &&
           !MatchesFilter(test_tag, negative.c_str()));
+}
+
+// Returns true if and only if the user-specified size matches the test
+// size.
+bool UnitTestOptions::SizeMatchesTest(const std::string& test_size) {
+  // Split --gtest_size at '-', if there is one, to separate into
+  // positive tag and negative tag portions
+  const char* const p = GTEST_FLAG(size).c_str();
+  const char* const dash = strchr(p, '-');
+  std::string positive;
+  std::string negative;
+  if (dash == nullptr) {
+    positive = GTEST_FLAG(size).c_str();  // Whole string is a positive tag
+    negative = "";
+  } else {
+    positive = std::string(p, dash);   // Everything up to the dash
+    negative = std::string(dash + 1);  // Everything after the dash
+    if (positive.empty()) {
+      // Treat '-test1' as the same as '*-test1'
+      positive = kUniversalFilter;
+    }
+  }
+
+  // A tag is a colon-separated list of patterns.  It matches a
+  // test if any pattern in it matches the test.
+  return (MatchesFilter(test_size, positive.c_str()) &&
+          !MatchesFilter(test_size, negative.c_str()));
 }
 
 #if GTEST_HAS_SEH
@@ -2756,7 +2808,8 @@ bool Test::IsSkipped() {
 // Constructs a TestInfo object. It assumes ownership of the test factory
 // object.
 TestInfo::TestInfo(const std::string& a_test_suite_name,
-                   const std::string& a_name, const std::string& a_tag,
+                   const std::string& a_name,
+                   char a_size, const std::string& a_tag,
                    const char* a_type_param, const char* a_value_param,
                    internal::CodeLocation a_code_location,
                    internal::TypeId fixture_class_id,
@@ -2764,6 +2817,7 @@ TestInfo::TestInfo(const std::string& a_test_suite_name,
     : test_suite_name_(a_test_suite_name),
       name_(a_name),
       tag_(a_tag),
+      size_(a_size),
       type_param_(a_type_param ? new std::string(a_type_param) : nullptr),
       value_param_(a_value_param ? new std::string(a_value_param) : nullptr),
       location_(a_code_location),
@@ -2772,6 +2826,7 @@ TestInfo::TestInfo(const std::string& a_test_suite_name,
       is_disabled_(false),
       matches_filter_(false),
       matches_tag_(false),
+      matches_size_(false),
       factory_(factory),
       result_() {}
 
@@ -2787,6 +2842,7 @@ namespace internal {
 //
 //   test_suite_name:   name of the test suite
 //   name:             name of the test
+//   size:             size of the test
 //   tag:              tag of the test
 //   type_param:       the name of the test's type parameter, or NULL if
 //                     this is not a typed or a type-parameterized test.
@@ -2800,12 +2856,12 @@ namespace internal {
 //                     The newly created TestInfo instance will assume
 //                     ownership of the factory object.
 TestInfo* MakeAndRegisterTestInfo(
-    const char* test_suite_name, const char* name, const char* tag,
+    const char* test_suite_name, const char* name, char size, const char* tag,
     const char* type_param, const char* value_param, CodeLocation code_location,
     TypeId fixture_class_id, SetUpTestSuiteFunc set_up_tc,
     TearDownTestSuiteFunc tear_down_tc, TestFactoryBase* factory) {
   TestInfo* const test_info =
-      new TestInfo(test_suite_name, name, tag, type_param, value_param,
+      new TestInfo(test_suite_name, name, size, tag, type_param, value_param,
                    code_location, fixture_class_id, factory);
   GetUnitTestImpl()->AddTestInfo(set_up_tc, tear_down_tc, test_info);
   return test_info;
@@ -3450,6 +3506,15 @@ void PrettyUnitTestResultPrinter::OnTestIterationStart(
   if (!String::CStringEquals(tag, kUniversalFilter)) {
     ColoredPrintf(GTestColor::kYellow, "Note: %s tag = %s\n",
                   GTEST_NAME_, tag);
+  }
+
+  const char* const size = GTEST_FLAG(size).c_str();
+
+  // Prints the size if it's not *.  This reminds the user that some
+  // tests may be skipped.
+  if (!String::CStringEquals(size, kUniversalFilter)) {
+    ColoredPrintf(GTestColor::kYellow, "Note: %s size = %s\n",
+                  GTEST_NAME_, size);
   }
 
   if (internal::ShouldShard(kTestTotalShards, kTestShardIndex, false)) {
@@ -5958,6 +6023,7 @@ int UnitTestImpl::FilterTests(ReactionToSharding shard_tests) {
       TestInfo* const test_info = test_suite->test_info_list()[j];
       const std::string test_name(test_info->name());
       const std::string test_tag(test_info->tag());
+      const std::string test_size(1, test_info->size());
       // A test is disabled if test suite name or test name matches
       // kDisableTestFilter.
       const bool is_disabled = internal::UnitTestOptions::MatchesFilter(
@@ -5971,12 +6037,14 @@ int UnitTestImpl::FilterTests(ReactionToSharding shard_tests) {
       test_info->matches_filter_ = matches_filter;
 
       const bool matches_tag = internal::UnitTestOptions::TagMatchesTest(test_tag);
-
       test_info->matches_tag_ = matches_tag;
+
+      const bool matches_size = internal::UnitTestOptions::SizeMatchesTest(test_size);
+      test_info->matches_size_ = matches_size;
 
       const bool is_runnable =
           (GTEST_FLAG(also_run_disabled_tests) || !is_disabled) &&
-          matches_filter && matches_tag;
+          matches_filter && matches_size && matches_tag;
 
       const bool is_in_another_shard =
           shard_tests != IGNORE_SHARDING_PROTOCOL &&
@@ -6026,7 +6094,8 @@ void UnitTestImpl::ListTestsMatchingFilter() {
 
     for (size_t j = 0; j < test_suite->test_info_list().size(); j++) {
       const TestInfo* const test_info = test_suite->test_info_list()[j];
-      if (test_info->matches_filter_ && test_info->matches_tag_) {
+      if (test_info->matches_filter_ && test_info->matches_size_ &&
+          test_info->matches_tag_) {
         if (!printed_test_suite_name) {
           printed_test_suite_name = true;
           printf("%s.", test_suite->name());
@@ -6353,6 +6422,13 @@ static const char kColorEncodedHelpMessage[] =
     "'*'\n"
     "      matches any substring; ':' separates two patterns.\n"
     "  @G--" GTEST_FLAG_PREFIX_
+    "size=@YPOSTIVE_PATTERNS"
+    "[@G-@YNEGATIVE_PATTERNS]@D\n"
+    "      Run only the tests whose size matches one of the positive "
+    "patterns but\n"
+    "      none of the negative patterns. "
+    "'*'\n"
+    "  @G--" GTEST_FLAG_PREFIX_
     "also_run_disabled_tests@D\n"
     "      Run all disabled tests too.\n"
     "\n"
@@ -6441,6 +6517,7 @@ static bool ParseGoogleTestFlag(const char* const arg) {
          ParseBoolFlag(arg, kFailFast, &GTEST_FLAG(fail_fast)) ||
          ParseStringFlag(arg, kFilterFlag, &GTEST_FLAG(filter)) ||
          ParseStringFlag(arg, kTagFlag, &GTEST_FLAG(tag)) ||
+         ParseStringFlag(arg, kSizeFlag, &GTEST_FLAG(size)) ||
          ParseStringFlag(arg, kInternalRunDeathTestFlag,
                          &GTEST_FLAG(internal_run_death_test)) ||
          ParseBoolFlag(arg, kListTestsFlag, &GTEST_FLAG(list_tests)) ||


### PR DESCRIPTION
Adds the ability to add test size and tags to individual tests. Also allows consuming code to turnoff the default macros.

This is based off the the https://github.com/Esri/googletest/tree/tag_size branch