### PR TITLE
Fix a clang warning

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -730,7 +730,7 @@ class GTEST_API_ TestInfo {
   const char* tag() const { return tag_.c_str(); }
 
   // Returns the test size.
-  const char size() const { return size_; }
+  char size() const { return size_; }
 
   // Returns the name of the parameter type, or NULL if this is not a typed
   // or a type-parameterized test.


### PR DESCRIPTION
Minor change to fix the following warning:
```
error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
```