### PR TITLE
Add NOLINT for esri-no-implementation-in-headers

### DIFF
--- a/googlemock/include/gmock/gmock-function-mocker.h
+++ b/googlemock/include/gmock/gmock-function-mocker.h
@@ -108,11 +108,13 @@ constexpr bool ValidateSpec(const char (&spec)[N]) {
 using internal::FunctionMocker;
 }  // namespace testing
 
+// NOLINTBEGIN(esri-no-implementation-in-headers)
 #define MOCK_METHOD(...)                                               \
   GMOCK_INTERNAL_WARNING_PUSH()                                        \
   GMOCK_INTERNAL_WARNING_CLANG(ignored, "-Wunused-member-function")    \
   GMOCK_PP_VARIADIC_CALL(GMOCK_INTERNAL_MOCK_METHOD_ARG_, __VA_ARGS__) \
   GMOCK_INTERNAL_WARNING_POP()
+// NOLINTEND(esri-no-implementation-in-headers)
 
 #define GMOCK_INTERNAL_MOCK_METHOD_ARG_1(...) \
   GMOCK_INTERNAL_WRONG_ARITY(__VA_ARGS__)


### PR DESCRIPTION
The MOCK_METHOD macro implements member functions inline and therefore violates the esri-no-implementation-in-headers clang-tidy checker. Surround the macro definition with NOLINTBEGIN/NOLINTEND to disable the checker for this case.